### PR TITLE
Iterable MockLists

### DIFF
--- a/src/mock.js
+++ b/src/mock.js
@@ -194,6 +194,11 @@ class MockList {
     }
   }
 
+  *[Symbol.iterator]() {
+    const arr = this.mock();
+    for (let value of arr) yield value;
+  }
+
   mock(o, a, c, r, fieldType, mockTypeFunc) {
     function randint(low, high) {
       return Math.floor(Math.random() * (high - low + 1) + low);


### PR DESCRIPTION
I find myself joining MockList generated data with hard-coded fixtures. It'd be a nice little shortcut to directly iterate a MockList without calling `mock()`:

``` js
...(new MockList([1, 3]).mock())
```

We can do this instead:

``` js
...(new MockList([1, 3]))
```
